### PR TITLE
Enhance landing interactions and consultation flow

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -89,6 +89,17 @@
     transform: translateY(0);
   }
 
+  [data-animate] {
+    opacity: 0;
+    transform: translateY(32px);
+    transition: opacity 0.7s ease, transform 0.7s ease;
+  }
+
+  [data-animate].is-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
   .bg-theme {
     background-color: var(--theme-color);
   }
@@ -103,5 +114,21 @@
 
   .ring-theme {
     --tw-ring-color: var(--theme-color);
+  }
+
+  .typing-cursor {
+    display: inline-block;
+    width: 1px;
+    height: 1.1em;
+    margin-left: 4px;
+    background-color: currentColor;
+    animation: typing-blink 1s steps(2, start) infinite;
+    vertical-align: bottom;
+  }
+}
+
+@keyframes typing-blink {
+  to {
+    visibility: hidden;
   }
 }

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,4 +1,15 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useLocation } from "wouter";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { useToast } from "@/hooks/use-toast";
+import { apiRequest } from "@/lib/queryClient";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { NaverMap } from "@/components/naver-map";
 import {
   ArrowRight,
   CalendarRange,
@@ -13,7 +24,6 @@ import {
   ShieldCheck,
   Sparkles,
 } from "lucide-react";
-import { useLocation } from "wouter";
 import heroCar from "@assets/xw0MTtfRZ3rCjnBiosoX8_1758442035276.png";
 
 const highlights = [
@@ -71,10 +81,10 @@ const steps = [
   },
 ];
 
-const stats = [
-  { label: "연간 배차 건수", value: "12,000+" },
-  { label: "재이용 고객 비율", value: "92%" },
-  { label: "전담 매니저", value: "24h" },
+const statsData = [
+  { label: "연간 배차 건수", value: 12000, suffix: "+" },
+  { label: "재이용 고객 비율", value: 92, suffix: "%" },
+  { label: "전담 매니저", value: 24, suffix: "h" },
 ];
 
 const testimonials = [
@@ -96,13 +106,167 @@ const testimonials = [
 ];
 
 export default function Landing() {
+  const pageRef = useRef<HTMLDivElement>(null);
+  const statsRef = useRef<HTMLDivElement>(null);
   const [, navigate] = useLocation();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [formData, setFormData] = useState({ name: "", phone: "", inquiry: "" });
+  const [animatedStats, setAnimatedStats] = useState<number[]>(() => statsData.map(() => 0));
+  const [statsActivated, setStatsActivated] = useState(false);
+  const [testimonialIndex, setTestimonialIndex] = useState(0);
+  const [typedText, setTypedText] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const mutation = useMutation({
+    mutationFn: async (data: typeof formData) => {
+      const res = await apiRequest("POST", "/api/inquiries", data);
+      return await res.json();
+    },
+    onSuccess: () => {
+      toast({
+        title: "상담 신청 완료",
+        description: "담당 매니저가 빠르게 연락드리겠습니다.",
+      });
+      setFormData({ name: "", phone: "", inquiry: "" });
+      setIsDialogOpen(false);
+      queryClient.invalidateQueries({ queryKey: ["/api/inquiries"] });
+    },
+    onError: () => {
+      toast({
+        title: "신청 실패",
+        description: "상담 신청 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  useEffect(() => {
+    const container = pageRef.current;
+    const elements = container?.querySelectorAll<HTMLElement>("[data-animate]");
+    if (!elements?.length) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("is-visible");
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: 0.2 },
+    );
+
+    elements.forEach((el) => {
+      const delay = el.dataset.animateDelay;
+      if (delay) {
+        el.style.transitionDelay = delay;
+      }
+      observer.observe(el);
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!statsRef.current) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setStatsActivated(true);
+          observer.disconnect();
+        }
+      },
+      { threshold: 0.5 },
+    );
+
+    observer.observe(statsRef.current);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    if (!statsActivated) return;
+    const duration = 1500;
+    const start = performance.now();
+
+    const easeOutCubic = (t: number) => 1 - Math.pow(1 - t, 3);
+
+    let frameId = 0;
+
+    const step = (time: number) => {
+      const progress = Math.min((time - start) / duration, 1);
+      const eased = easeOutCubic(progress);
+      setAnimatedStats(statsData.map((stat) => Math.round(stat.value * eased)));
+      if (progress < 1) {
+        frameId = requestAnimationFrame(step);
+      }
+    };
+
+    frameId = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(frameId);
+  }, [statsActivated]);
+
+  useEffect(() => {
+    const current = testimonials[testimonialIndex];
+    if (!current) return;
+
+    if (isDeleting && typedText === "") {
+      setIsDeleting(false);
+      setTestimonialIndex((prev) => (prev + 1) % testimonials.length);
+      return;
+    }
+
+    if (!isDeleting && typedText === current.quote) {
+      const holdTimer = window.setTimeout(() => setIsDeleting(true), 1600);
+      return () => window.clearTimeout(holdTimer);
+    }
+
+    const timer = window.setTimeout(() => {
+      const nextLength = typedText.length + (isDeleting ? -1 : 1);
+      setTypedText(current.quote.slice(0, Math.max(0, nextLength)));
+    }, isDeleting ? 18 : 45);
+
+    return () => window.clearTimeout(timer);
+  }, [isDeleting, testimonialIndex, typedText]);
+
+  const currentTestimonial = useMemo(
+    () => testimonials[testimonialIndex] ?? testimonials[0],
+    [testimonialIndex],
+  );
+
+  const handleFormChange = (field: keyof typeof formData, value: string) => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!formData.name.trim() || !formData.phone.trim() || !formData.inquiry.trim()) {
+      toast({
+        title: "입력 확인",
+        description: "이름, 연락처, 문의 내용을 모두 입력해주세요.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    mutation.mutate({
+      name: formData.name.trim(),
+      phone: formData.phone.trim(),
+      inquiry: formData.inquiry.trim(),
+    });
+  };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-50">
+    <div
+      ref={pageRef}
+      className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-50"
+    >
       <header className="fixed top-0 inset-x-0 z-40 border-b border-white/10 bg-slate-950/80 backdrop-blur-xl">
         <div className="container mx-auto flex items-center justify-between px-4 py-5">
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3" data-animate>
             <div className="flex h-12 w-12 items-center justify-center rounded-full bg-sky-500/20 text-sky-400">
               <Car className="h-6 w-6" />
             </div>
@@ -112,7 +276,7 @@ export default function Landing() {
             </div>
           </div>
 
-          <div className="hidden items-center gap-10 text-sm font-medium text-slate-200 md:flex">
+          <div className="hidden items-center gap-10 text-sm font-medium text-slate-200 md:flex" data-animate data-animate-delay="0.05s">
             <a href="#fleet" className="transition hover:text-white">
               서비스 소개
             </a>
@@ -127,6 +291,8 @@ export default function Landing() {
           <a
             href="tel:02-123-4567"
             className="flex items-center gap-2 rounded-full bg-sky-500 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:-translate-y-0.5 hover:bg-sky-400"
+            data-animate
+            data-animate-delay="0.1s"
           >
             <PhoneCall className="h-4 w-4" />
             02-123-4567
@@ -139,19 +305,32 @@ export default function Landing() {
           <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(56,189,248,0.15),_transparent_60%)]" />
           <div className="container mx-auto grid items-center gap-12 px-4 pb-24 pt-12 md:grid-cols-[1.05fr_0.95fr]">
             <div className="space-y-8">
-              <div className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.35em] text-sky-300">
+              <div
+                className="inline-flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs uppercase tracking-[0.35em] text-sky-300"
+                data-animate
+              >
                 tailored luxury
               </div>
-              <h2 className="text-4xl font-semibold leading-[1.15] text-white md:text-6xl">
+              <h2
+                className="text-4xl font-semibold leading-[1.15] text-white md:text-6xl"
+                data-animate
+                data-animate-delay="0.05s"
+              >
                 맞춤 컨설팅으로 완성하는<br />
                 <span className="text-sky-400">프리미엄 차량 렌탈 서비스</span>
               </h2>
-              <p className="text-base leading-relaxed text-slate-200 md:text-lg">
-                일정, 동선, 목적에 따라 가장 완벽한 이동 경험을 설계해 드립니다. 첫 문의부터 차량 반납까지 모든 과정을
-                전담 매니저가 케어해 드리는 서울 프리미엄 렌트 전용 서비스입니다.
+              <p
+                className="text-base leading-relaxed text-slate-200 md:text-lg"
+                data-animate
+                data-animate-delay="0.1s"
+              >
+                일정, 동선, 목적에 따라 가장 완벽한 이동 경험을 설계해 드립니다. 첫 문의부터 차량 반납까지 모든 과정을 전담 매니저가 케어해 드리는 서울 프리미엄 렌트 전용 서비스입니다.
               </p>
-              <div className="flex flex-col gap-3 sm:flex-row">
-                <Button className="group flex items-center gap-2 rounded-full bg-sky-500 px-8 py-6 text-base font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:-translate-y-0.5 hover:bg-sky-400">
+              <div className="flex flex-col gap-3 sm:flex-row" data-animate data-animate-delay="0.15s">
+                <Button
+                  className="group flex items-center gap-2 rounded-full bg-sky-500 px-8 py-6 text-base font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:-translate-y-0.5 hover:bg-sky-400"
+                  onClick={() => setIsDialogOpen(true)}
+                >
                   컨시어지 예약하기
                   <ArrowRight className="h-5 w-5 transition-transform group-hover:translate-x-1" />
                 </Button>
@@ -162,10 +341,18 @@ export default function Landing() {
                   <PhoneCall className="h-5 w-5" /> 전화 상담
                 </a>
               </div>
-              <div className="grid gap-4 md:grid-cols-3">
-                {stats.map((stat) => (
-                  <div key={stat.label} className="rounded-2xl border border-white/5 bg-white/5 p-5">
-                    <p className="text-3xl font-semibold text-white">{stat.value}</p>
+              <div className="grid gap-4 md:grid-cols-3" ref={statsRef}>
+                {statsData.map((stat, index) => (
+                  <div
+                    key={stat.label}
+                    className="rounded-2xl border border-white/5 bg-white/5 p-5"
+                    data-animate
+                    data-animate-delay={`${0.15 + index * 0.05}s`}
+                  >
+                    <p className="text-3xl font-semibold text-white">
+                      {animatedStats[index]?.toLocaleString("ko-KR")}
+                      {statsActivated ? stat.suffix : ""}
+                    </p>
                     <p className="mt-1 text-sm text-slate-300">{stat.label}</p>
                   </div>
                 ))}
@@ -175,7 +362,11 @@ export default function Landing() {
             <div className="relative">
               <div className="absolute -left-8 top-10 h-64 w-64 rounded-full bg-sky-500/20 blur-3xl" />
               <div className="absolute -right-6 bottom-0 h-56 w-56 rounded-full bg-cyan-400/20 blur-3xl" />
-              <div className="relative rounded-[48px] border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-white/0 p-10 shadow-2xl backdrop-blur">
+              <div
+                className="relative rounded-[48px] border border-white/10 bg-gradient-to-br from-white/10 via-white/5 to-white/0 p-10 shadow-2xl backdrop-blur"
+                data-animate
+                data-animate-delay="0.25s"
+              >
                 <div className="absolute inset-0 rounded-[48px] border border-white/10" />
                 <img
                   src={heroCar}
@@ -203,18 +394,19 @@ export default function Landing() {
           <div className="container mx-auto grid gap-12 px-4 md:grid-cols-[1.1fr_0.9fr]">
             <div className="space-y-8">
               <p className="text-sm uppercase tracking-[0.35em] text-sky-300">signature service</p>
-              <h3 className="text-3xl font-semibold text-white md:text-4xl">
+              <h3 className="text-3xl font-semibold text-white md:text-4xl" data-animate>
                 서울 전 지역 프리미엄 맞춤 렌탈 & 리무진 컨시어지
               </h3>
-              <p className="text-base leading-relaxed text-slate-200">
-                수입차 단기 렌트부터 VIP 의전, 웨딩 차량까지 목적별 이동 솔루션을 제공해 드립니다. 스케줄 관리, 기사 배정,
-                주유 및 세차까지 매 순간 최고의 컨디션을 유지합니다.
+              <p className="text-base leading-relaxed text-slate-200" data-animate data-animate-delay="0.05s">
+                수입차 단기 렌트부터 VIP 의전, 웨딩 차량까지 목적별 이동 솔루션을 제공해 드립니다. 스케줄 관리, 기사 배정, 주유 및 세차까지 매 순간 최고의 컨디션을 유지합니다.
               </p>
               <div className="grid gap-6 md:grid-cols-3">
-                {highlights.map((highlight) => (
+                {highlights.map((highlight, index) => (
                   <div
                     key={highlight.title}
                     className="flex flex-col gap-4 rounded-2xl border border-white/10 bg-slate-950/40 p-6 backdrop-blur"
+                    data-animate
+                    data-animate-delay={`${0.1 + index * 0.05}s`}
                   >
                     <div className="flex h-12 w-12 items-center justify-center rounded-full bg-sky-500/15 text-sky-300">
                       <highlight.icon className="h-6 w-6" />
@@ -229,10 +421,12 @@ export default function Landing() {
             </div>
 
             <div className="flex flex-col gap-6" id="fleet">
-              {fleet.map((item) => (
+              {fleet.map((item, index) => (
                 <div
                   key={item.name}
                   className="rounded-3xl border border-white/10 bg-gradient-to-r from-white/10 via-white/5 to-transparent p-8 shadow-xl"
+                  data-animate
+                  data-animate-delay={`${0.1 + index * 0.05}s`}
                 >
                   <div className="flex items-center justify-between gap-4">
                     <div>
@@ -263,11 +457,15 @@ export default function Landing() {
         <section id="process" className="border-b border-white/5 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 py-24">
           <div className="container mx-auto px-4">
             <div className="mb-12 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-              <div>
+              <div data-animate>
                 <p className="text-sm uppercase tracking-[0.35em] text-sky-300">how it works</p>
                 <h3 className="mt-4 text-3xl font-semibold text-white md:text-4xl">3단계로 완료되는 프리미엄 예약 프로세스</h3>
               </div>
-              <div className="rounded-2xl border border-white/10 bg-white/5 px-6 py-4 text-sm text-slate-200">
+              <div
+                className="rounded-2xl border border-white/10 bg-white/5 px-6 py-4 text-sm text-slate-200"
+                data-animate
+                data-animate-delay="0.1s"
+              >
                 <p className="flex items-center gap-2">
                   <CalendarRange className="h-4 w-4 text-sky-300" /> 모든 상담은 24시간 이내 응답 드립니다.
                 </p>
@@ -278,6 +476,8 @@ export default function Landing() {
                 <div
                   key={step.title}
                   className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 backdrop-blur"
+                  data-animate
+                  data-animate-delay={`${0.05 + index * 0.08}s`}
                 >
                   <div className="absolute -left-12 top-1/2 h-24 w-24 -translate-y-1/2 rounded-full bg-sky-500/10 blur-2xl" />
                   <div className="flex items-center justify-between">
@@ -293,18 +493,32 @@ export default function Landing() {
         </section>
 
         <section className="border-b border-white/5 bg-white/5 py-20">
-          <div className="container mx-auto grid gap-10 px-4 md:grid-cols-[0.9fr_1.1fr]">
-            <div className="space-y-6">
+          <div className="container mx-auto grid gap-10 px-4 md:grid-cols-[0.95fr_1.05fr]">
+            <div className="space-y-6" data-animate>
               <p className="text-sm uppercase tracking-[0.35em] text-sky-300">client stories</p>
               <h3 className="text-3xl font-semibold text-white md:text-4xl">고객이 말하는 서울 프리미엄 렌트</h3>
               <p className="text-sm leading-relaxed text-slate-200">
-                반복 이용 고객들의 신뢰로 성장한 프리미엄 렌탈 서비스. 목적에 맞춘 차량, 매너 있는 드라이버, 그리고 전담 매니저의
-                섬세한 케어까지 경험해 보세요.
+                반복 이용 고객들의 신뢰로 성장한 프리미엄 렌탈 서비스. 목적에 맞춘 차량, 매너 있는 드라이버, 그리고 전담 매니저의 섬세한 케어까지 경험해 보세요.
               </p>
+              <div className="rounded-3xl border border-white/10 bg-slate-950/60 p-6 shadow-lg" data-animate data-animate-delay="0.05s">
+                <p className="text-xs uppercase tracking-[0.35em] text-sky-300">real voice</p>
+                <p className="mt-4 min-h-[120px] text-sm leading-relaxed text-slate-100">
+                  “{typedText}
+                  <span className="typing-cursor" />”
+                </p>
+                <p className="mt-4 text-xs font-semibold uppercase tracking-[0.2em] text-slate-400">
+                  {currentTestimonial?.name}
+                </p>
+              </div>
             </div>
             <div className="grid gap-6 md:grid-cols-3">
-              {testimonials.map((item) => (
-                <div key={item.name} className="flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-slate-950/40 p-6">
+              {testimonials.map((item, index) => (
+                <div
+                  key={item.name}
+                  className="flex h-full flex-col gap-4 rounded-3xl border border-white/10 bg-slate-950/40 p-6"
+                  data-animate
+                  data-animate-delay={`${0.1 + index * 0.05}s`}
+                >
                   <div className="flex items-center gap-2 text-sky-300">
                     <Sparkles className="h-4 w-4" /> verified review
                   </div>
@@ -318,14 +532,13 @@ export default function Landing() {
 
         <section id="contact" className="py-24">
           <div className="container mx-auto grid gap-12 px-4 md:grid-cols-[1fr_1fr]">
-            <div className="space-y-6">
+            <div className="space-y-6" data-animate>
               <p className="text-sm uppercase tracking-[0.35em] text-sky-300">contact concierge</p>
               <h3 className="text-3xl font-semibold text-white md:text-4xl">
                 지금 바로 맞춤 렌탈 상담을 예약해 보세요
               </h3>
               <p className="text-sm leading-relaxed text-slate-200">
-                원하는 차량, 이용 일정, 기사 동반 여부를 알려주시면 가장 효율적인 플랜을 제안해 드립니다. 위급한 일정도 실시간으로
-                빠르게 배차해 드려요.
+                원하는 차량, 이용 일정, 기사 동반 여부를 알려주시면 가장 효율적인 플랜을 제안해 드립니다. 위급한 일정도 실시간으로 빠르게 배차해 드려요.
               </p>
               <div className="flex flex-col gap-3 text-sm text-slate-200">
                 <p className="flex items-center gap-3">
@@ -340,29 +553,50 @@ export default function Landing() {
               </div>
             </div>
 
-            <div className="relative overflow-hidden rounded-[40px] border border-white/10 bg-white/5 p-8 backdrop-blur">
-              <div className="absolute -top-20 -right-20 h-60 w-60 rounded-full bg-sky-500/20 blur-3xl" />
-              <div className="relative space-y-6">
-                <h4 className="text-2xl font-semibold text-white">컨시어지 상담 신청</h4>
-                <p className="text-sm leading-relaxed text-slate-200">
-                  아래 버튼을 클릭하시면 빠른 상담 전화를 도와드립니다. 필요 시 카카오톡, 이메일 등 원하는 채널로 이어서 상담합니다.
-                </p>
-                <div className="grid gap-3">
-                  <Button className="flex items-center justify-center gap-2 rounded-full bg-sky-500 px-6 py-5 text-base font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:-translate-y-0.5 hover:bg-sky-400">
-                    즉시 상담 연결
-                    <ArrowRight className="h-5 w-5" />
-                  </Button>
-                  <a
-                    href="tel:02-123-4567"
-                    className="flex items-center justify-center gap-2 rounded-full border border-white/20 px-6 py-5 text-base font-semibold text-white transition hover:-translate-y-0.5 hover:border-white/40"
-                  >
-                    <PhoneCall className="h-5 w-5" /> 전화 바로 걸기
-                  </a>
-                </div>
-                <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-slate-300">
-                  <p className="flex items-center gap-2">
-                    <ShieldCheck className="h-4 w-4 text-sky-300" /> 모든 차량은 출고 3년 이내, 주행거리 5만km 이하 차량만 배차합니다.
+            <div className="relative space-y-6">
+              <div
+                className="overflow-hidden rounded-[30px] border border-white/10 bg-slate-950/40 shadow-xl"
+                data-animate
+              >
+                <NaverMap
+                  height="260px"
+                  address="서울특별시 강남구 테헤란로 123"
+                  addressLabel="서울 프리미엄 렌트 라운지"
+                  fallbackCenter={{ lat: 37.501274, lng: 127.039585 }}
+                  className="rounded-[30px]"
+                />
+              </div>
+              <div
+                className="relative overflow-hidden rounded-[40px] border border-white/10 bg-white/5 p-8 backdrop-blur"
+                data-animate
+                data-animate-delay="0.08s"
+              >
+                <div className="absolute -top-20 -right-20 h-60 w-60 rounded-full bg-sky-500/20 blur-3xl" />
+                <div className="relative space-y-6">
+                  <h4 className="text-2xl font-semibold text-white">컨시어지 상담 신청</h4>
+                  <p className="text-sm leading-relaxed text-slate-200">
+                    아래 버튼을 클릭하시면 빠른 상담 전화를 도와드립니다. 필요 시 카카오톡, 이메일 등 원하는 채널로 이어서 상담합니다.
                   </p>
+                  <div className="grid gap-3">
+                    <Button
+                      className="flex items-center justify-center gap-2 rounded-full bg-sky-500 px-6 py-5 text-base font-semibold text-white shadow-lg shadow-sky-500/30 transition hover:-translate-y-0.5 hover:bg-sky-400"
+                      onClick={() => setIsDialogOpen(true)}
+                    >
+                      즉시 상담 연결
+                      <ArrowRight className="h-5 w-5" />
+                    </Button>
+                    <a
+                      href="tel:02-123-4567"
+                      className="flex items-center justify-center gap-2 rounded-full border border-white/20 px-6 py-5 text-base font-semibold text-white transition hover:-translate-y-0.5 hover:border-white/40"
+                    >
+                      <PhoneCall className="h-5 w-5" /> 전화 바로 걸기
+                    </a>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4 text-xs text-slate-300">
+                    <p className="flex items-center gap-2">
+                      <ShieldCheck className="h-4 w-4 text-sky-300" /> 모든 차량은 출고 3년 이내, 주행거리 5만km 이하 차량만 배차합니다.
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -382,12 +616,58 @@ export default function Landing() {
 
       <button
         onClick={() => navigate("/admin")}
-        className="fixed bottom-5 left-5 z-50 rounded-full border border-white/10 bg-slate-950/80 p-3 text-slate-200 shadow-lg backdrop-blur transition hover:-translate-y-0.5 hover:text-white"
+        className="fixed bottom-4 right-4 z-50 flex h-10 w-10 items-center justify-center rounded-full border border-white/20 bg-slate-950/80 text-slate-200 shadow-lg backdrop-blur transition hover:-translate-y-0.5 hover:text-white"
         aria-label="Admin settings"
         title="Admin"
       >
-        <Settings className="h-6 w-6" />
+        <Settings className="h-5 w-5" />
       </button>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>상담 예약 정보를 남겨주세요</DialogTitle>
+          </DialogHeader>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="consult-name">이름</Label>
+              <Input
+                id="consult-name"
+                value={formData.name}
+                onChange={(event) => handleFormChange("name", event.target.value)}
+                placeholder="이름을 입력해주세요"
+                autoComplete="name"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="consult-phone">연락처</Label>
+              <Input
+                id="consult-phone"
+                value={formData.phone}
+                onChange={(event) => handleFormChange("phone", event.target.value)}
+                placeholder="연락 가능한 전화번호"
+                autoComplete="tel"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="consult-message">문의 내용</Label>
+              <Textarea
+                id="consult-message"
+                value={formData.inquiry}
+                onChange={(event) => handleFormChange("inquiry", event.target.value)}
+                rows={4}
+                placeholder="원하시는 차량, 일정, 목적을 알려주세요"
+              />
+            </div>
+            <Button type="submit" className="w-full" disabled={mutation.isPending}>
+              {mutation.isPending ? "접수 중..." : "상담 신청하기"}
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              남겨주신 정보는 상담 목적 외에는 사용되지 않으며, 안전하게 보호됩니다.
+            </p>
+          </form>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- animate landing sections with scroll-based reveals, stat counters, and a testimonial typing effect
- embed a concierge consultation dialog tied to the existing inquiry API and show the lounge location on a Naver map
- reposition the admin shortcut button for easier discovery and add supporting utility styles

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4f0eef600832da12cdff5fb663f5e