### PR TITLE
Use dedicated landing database

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from "drizzle-kit";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL, ensure the database is provisioned");
+const landingDatabaseUrl = process.env.LANDING_DATABASE_URL;
+
+if (!landingDatabaseUrl) {
+  throw new Error("LANDING_DATABASE_URL must be set; ensure the landing database is provisioned");
 }
 
 export default defineConfig({
@@ -9,6 +11,6 @@ export default defineConfig({
   schema: "./shared/schema.ts",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL,
+    url: landingDatabaseUrl,
   },
 });

--- a/server/db.ts
+++ b/server/db.ts
@@ -5,11 +5,13 @@ import * as schema from "@shared/schema";
 
 neonConfig.webSocketConstructor = ws;
 
-if (!process.env.DATABASE_URL) {
+const landingDatabaseUrl = process.env.LANDING_DATABASE_URL;
+
+if (!landingDatabaseUrl) {
   throw new Error(
-    "DATABASE_URL must be set. Did you forget to provision a database?",
+    "LANDING_DATABASE_URL must be set. Did you forget to provision the landing page database?",
   );
 }
 
-export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+export const pool = new Pool({ connectionString: landingDatabaseUrl });
 export const db = drizzle({ client: pool, schema });

--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -22,11 +22,17 @@ const getOidcConfig = memoize(
   { maxAge: 3600 * 1000 }
 );
 
+const landingDatabaseUrl = process.env.LANDING_DATABASE_URL;
+
+if (!landingDatabaseUrl) {
+  throw new Error("LANDING_DATABASE_URL must be set to configure session storage");
+}
+
 export function getSession() {
   const sessionTtl = 7 * 24 * 60 * 60 * 1000; // 1 week
   const pgStore = connectPg(session);
   const sessionStore = new pgStore({
-    conString: process.env.DATABASE_URL,
+    conString: landingDatabaseUrl,
     createTableIfMissing: false,
     ttl: sessionTtl,
     tableName: "sessions",


### PR DESCRIPTION
## Summary
- introduce a LANDING_DATABASE_URL environment variable for Drizzle and runtime database connections
- ensure the Neon pool, Drizzle client, and Replit session store connect to the landing database URL

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4f610f218832da8f0bdf796ca5878