### PR TITLE
Allow running without landing database

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -8,10 +8,15 @@ neonConfig.webSocketConstructor = ws;
 const landingDatabaseUrl = process.env.LANDING_DATABASE_URL;
 
 if (!landingDatabaseUrl) {
-  throw new Error(
-    "LANDING_DATABASE_URL must be set. Did you forget to provision the landing page database?",
+  console.warn(
+    "LANDING_DATABASE_URL is not set. Falling back to in-memory storage for development.",
   );
 }
 
-export const pool = new Pool({ connectionString: landingDatabaseUrl });
-export const db = drizzle({ client: pool, schema });
+export const pool = landingDatabaseUrl
+  ? new Pool({ connectionString: landingDatabaseUrl })
+  : undefined;
+
+export const db = landingDatabaseUrl
+  ? drizzle({ client: pool!, schema })
+  : undefined;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "crypto";
 import {
   users,
   inquiries,
@@ -37,14 +38,22 @@ export interface IStorage {
 }
 
 export class DatabaseStorage implements IStorage {
+  private readonly db = db;
+
+  constructor() {
+    if (!this.db) {
+      throw new Error("Database connection is not configured.");
+    }
+  }
+
   // User operations
   async getUser(id: string): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.id, id));
+    const [user] = await this.db!.select().from(users).where(eq(users.id, id));
     return user;
   }
 
   async upsertUser(userData: UpsertUser): Promise<User> {
-    const [user] = await db
+    const [user] = await this.db!
       .insert(users)
       .values(userData)
       .onConflictDoUpdate({
@@ -60,7 +69,7 @@ export class DatabaseStorage implements IStorage {
 
   // Inquiry operations
   async createInquiry(inquiryData: InsertInquiry): Promise<Inquiry> {
-    const [inquiry] = await db
+    const [inquiry] = await this.db!
       .insert(inquiries)
       .values(inquiryData)
       .returning();
@@ -68,14 +77,14 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getAllInquiries(): Promise<Inquiry[]> {
-    return await db
+    return await this.db!
       .select()
       .from(inquiries)
       .orderBy(desc(inquiries.createdAt));
   }
 
   async updateInquiryStatus(id: string, status: string): Promise<void> {
-    await db
+    await this.db!
       .update(inquiries)
       .set({ status })
       .where(eq(inquiries.id, id));
@@ -83,7 +92,7 @@ export class DatabaseStorage implements IStorage {
 
   // Service type operations
   async getAllServiceTypes(): Promise<ServiceType[]> {
-    return await db
+    return await this.db!
       .select()
       .from(serviceTypes)
       .where(eq(serviceTypes.isActive, "active"))
@@ -91,7 +100,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createServiceType(serviceTypeData: InsertServiceType): Promise<ServiceType> {
-    const [serviceType] = await db
+    const [serviceType] = await this.db!
       .insert(serviceTypes)
       .values(serviceTypeData)
       .returning();
@@ -100,7 +109,7 @@ export class DatabaseStorage implements IStorage {
 
   // Appointment operations
   async createAppointment(appointmentData: InsertAppointment): Promise<Appointment> {
-    const [appointment] = await db
+    const [appointment] = await this.db!
       .insert(appointments)
       .values(appointmentData)
       .returning();
@@ -108,7 +117,7 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getAllAppointments(): Promise<Appointment[]> {
-    return await db
+    return await this.db!
       .select()
       .from(appointments)
       .orderBy(desc(appointments.appointmentDate));
@@ -119,7 +128,7 @@ export class DatabaseStorage implements IStorage {
     const endOfDay = new Date(date);
     endOfDay.setHours(23, 59, 59, 999);
     
-    return await db
+    return await this.db!
       .select()
       .from(appointments)
       .where(
@@ -132,11 +141,146 @@ export class DatabaseStorage implements IStorage {
   }
 
   async updateAppointmentStatus(id: string, status: string): Promise<void> {
-    await db
+    await this.db!
       .update(appointments)
       .set({ status, updatedAt: new Date() })
       .where(eq(appointments.id, id));
   }
 }
 
-export const storage = new DatabaseStorage();
+class InMemoryStorage implements IStorage {
+  private users = new Map<string, User>();
+  private inquiries: Inquiry[] = [];
+  private serviceTypes: ServiceType[] = [];
+  private appointments: Appointment[] = [];
+
+  async getUser(id: string): Promise<User | undefined> {
+    return this.users.get(id);
+  }
+
+  async upsertUser(userData: UpsertUser): Promise<User> {
+    const id = userData.id ?? randomUUID();
+    const now = new Date();
+    const existing = this.users.get(id);
+
+    const user: User = {
+      id,
+      email: userData.email ?? existing?.email ?? null,
+      firstName: userData.firstName ?? existing?.firstName ?? null,
+      lastName: userData.lastName ?? existing?.lastName ?? null,
+      profileImageUrl: userData.profileImageUrl ?? existing?.profileImageUrl ?? null,
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+
+    this.users.set(id, user);
+    return user;
+  }
+
+  async createInquiry(inquiryData: InsertInquiry): Promise<Inquiry> {
+    const inquiry: Inquiry = {
+      id: randomUUID(),
+      name: inquiryData.name,
+      phone: inquiryData.phone,
+      inquiry: inquiryData.inquiry,
+      createdAt: new Date(),
+      status: "new",
+    };
+
+    this.inquiries = [inquiry, ...this.inquiries];
+    return inquiry;
+  }
+
+  async getAllInquiries(): Promise<Inquiry[]> {
+    return [...this.inquiries].sort((a, b) => {
+      const bTime = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+      const aTime = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+      return bTime - aTime;
+    });
+  }
+
+  async updateInquiryStatus(id: string, status: string): Promise<void> {
+    const inquiry = this.inquiries.find((item) => item.id === id);
+    if (inquiry) {
+      inquiry.status = status;
+    }
+  }
+
+  async getAllServiceTypes(): Promise<ServiceType[]> {
+    return this.serviceTypes
+      .filter((serviceType) => serviceType.isActive === "active")
+      .sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+  }
+
+  async createServiceType(serviceTypeData: InsertServiceType): Promise<ServiceType> {
+    const serviceType: ServiceType = {
+      id: randomUUID(),
+      name: serviceTypeData.name,
+      description: serviceTypeData.description ?? null,
+      duration: serviceTypeData.duration,
+      price: serviceTypeData.price ?? null,
+      isActive: "active",
+      createdAt: new Date(),
+    };
+
+    this.serviceTypes.push(serviceType);
+    return serviceType;
+  }
+
+  async createAppointment(appointmentData: InsertAppointment): Promise<Appointment> {
+    const appointmentDate =
+      appointmentData.appointmentDate instanceof Date
+        ? appointmentData.appointmentDate
+        : new Date(appointmentData.appointmentDate);
+
+    const appointment: Appointment = {
+      id: randomUUID(),
+      name: appointmentData.name,
+      phone: appointmentData.phone,
+      email: appointmentData.email ?? null,
+      serviceTypeId: appointmentData.serviceTypeId ?? null,
+      appointmentDate,
+      notes: appointmentData.notes ?? null,
+      address: appointmentData.address ?? null,
+      latitude: appointmentData.latitude ?? null,
+      longitude: appointmentData.longitude ?? null,
+      status: "pending",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    this.appointments.push(appointment);
+    return appointment;
+  }
+
+  async getAllAppointments(): Promise<Appointment[]> {
+    return [...this.appointments].sort(
+      (a, b) => b.appointmentDate.getTime() - a.appointmentDate.getTime(),
+    );
+  }
+
+  async getAppointmentsByDate(date: string): Promise<Appointment[]> {
+    const targetDate = new Date(date);
+    const startOfDay = new Date(targetDate);
+    startOfDay.setHours(0, 0, 0, 0);
+    const endOfDay = new Date(targetDate);
+    endOfDay.setHours(23, 59, 59, 999);
+
+    return this.appointments.filter((appointment) => {
+      const time = appointment.appointmentDate.getTime();
+      return time >= startOfDay.getTime() && time <= endOfDay.getTime();
+    });
+  }
+
+  async updateAppointmentStatus(id: string, status: string): Promise<void> {
+    const appointment = this.appointments.find((item) => item.id === id);
+    if (appointment) {
+      appointment.status = status;
+      appointment.updatedAt = new Date();
+    }
+  }
+}
+
+export const storage: IStorage = process.env.LANDING_DATABASE_URL
+  ? new DatabaseStorage()
+  : new InMemoryStorage();


### PR DESCRIPTION
## Summary
- warn instead of throwing when LANDING_DATABASE_URL is missing and expose optional database handles
- add an in-memory storage implementation that is used when the landing database URL is absent
- relax Replit auth setup to fall back to in-memory sessions and disable itself without REPLIT_DOMAINS

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4f6fe2660832d9ebffaf82fc625bd