### PR TITLE
Respect failed Naver map loader state

### DIFF
--- a/client/src/components/naver-map.tsx
+++ b/client/src/components/naver-map.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { loadNaverMapsScript } from "@/lib/naver-maps-loader";
+import {
+  loadNaverMapsScript,
+  getNaverMapsScriptState,
+} from "@/lib/naver-maps-loader";
 
 // Declare naver global for TypeScript
 declare global {
@@ -51,6 +54,19 @@ export function NaverMap({width = "100%",
   // 1) 스크립트 '한 번만' 로드
   useEffect(() => {
     let cancelled = false;
+
+    const { state, error } = getNaverMapsScriptState();
+
+    if (state === "failed" && error) {
+      setLoadError(error.message);
+      return;
+    }
+
+    if (state === "loaded" && window.naver?.maps) {
+      setIsLoaded(true);
+      setLoadError(null);
+      return;
+    }
 
     loadNaverMapsScript()
       .then(() => {


### PR DESCRIPTION
## Summary
- read the cached Naver Maps loader state before attempting to initialize the script in the embedded map component
- surface any stored loader failure immediately without issuing another script request

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d4fd42f568832da25f76390ef83f3d