### PR TITLE
Fix card layout to render one card per row

### DIFF
--- a/client/src/components/ui/card.tsx
+++ b/client/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "w-full sm:w-auto rounded-lg border border-border/40 bg-card text-card-foreground shadow-sm",
+      "w-full rounded-lg border border-border/40 bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- remove the small-screen width override in the shared Card component so cards stay full-width
- ensure pages that rely on Card no longer render two cards per row unintentionally

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d75c3c5270832db8f9fc1824e08610