### PR TITLE
Scope image width styling per component

### DIFF
--- a/client/src/components/gallery-section.tsx
+++ b/client/src/components/gallery-section.tsx
@@ -94,7 +94,7 @@ export function GallerySection() {
                   <img
                     src={s.media as any}
                     alt={s.title}
-                    className="w-full h-[260px] md:h-[360px] object-cover"
+                    className="block h-[260px] w-full object-cover md:h-[360px]"
                     loading="lazy"
                   />
                 )}

--- a/client/src/components/services-section.tsx
+++ b/client/src/components/services-section.tsx
@@ -76,7 +76,11 @@ export function ServicesSection() {
                     <source src={service.media as any} type="video/mp4" />
                   </video>
                 ) : (
-                  <img src={service.media as any} alt={service.title} className="w-full h-full object-cover" />
+                  <img
+                    src={service.media as any}
+                    alt={service.title}
+                    className="block h-full w-full object-cover"
+                  />
                 )}
               </div>
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -75,6 +75,7 @@
   body {
     @apply bg-background text-foreground antialiased;
   }
+
 }
 
 @layer utilities {

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -76,7 +76,7 @@ function CardMedia({ media }: { media: MediaAsset }) {
     <img
       src={media.src}
       alt={media.alt ?? ""}
-      className="h-64 w-full object-cover md:h-80"
+      className="block h-64 w-full object-cover md:h-80"
       loading="lazy"
       aria-hidden={media.alt ? undefined : true}
     />


### PR DESCRIPTION
## Summary
- remove the global `img` base rule so shared styles return to their prior behavior
- explicitly apply block-level, full-width sizing to each rendered image component

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8a9bc8a38832db4699d619dae81fc