### PR TITLE
Make landing card media full-bleed

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -126,6 +126,16 @@
     animation: typing-blink 1s steps(2, start) infinite;
     vertical-align: bottom;
   }
+
+  .full-bleed {
+    position: relative;
+    left: 50%;
+    right: 50%;
+    margin-left: -50vw;
+    margin-right: -50vw;
+    width: 100vw;
+    max-width: none;
+  }
 }
 
 @keyframes typing-blink {

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -56,30 +56,37 @@ interface FleetItem {
 }
 
 function CardMedia({ media }: { media: MediaAsset }) {
+  const commonClasses = "block aspect-[16/9] w-full object-cover";
+  const wrapperClass = "full-bleed";
+
   if (media.type === "video") {
     return (
-      <video
-        className="aspect-[16/9] w-full object-cover"
-        autoPlay
-        loop
-        muted
-        playsInline
-        poster={media.poster}
-        aria-hidden="true"
-      >
-        <source src={media.src} type="video/mp4" />
-      </video>
+      <div className={wrapperClass}>
+        <video
+          className={commonClasses}
+          autoPlay
+          loop
+          muted
+          playsInline
+          poster={media.poster}
+          aria-hidden="true"
+        >
+          <source src={media.src} type="video/mp4" />
+        </video>
+      </div>
     );
   }
 
   return (
-    <img
-      src={media.src}
-      alt={media.alt ?? ""}
-      className="block aspect-[16/9] w-full object-cover"
-      loading="lazy"
-      aria-hidden={media.alt ? undefined : true}
-    />
+    <div className={wrapperClass}>
+      <img
+        src={media.src}
+        alt={media.alt ?? ""}
+        className={commonClasses}
+        loading="lazy"
+        aria-hidden={media.alt ? undefined : true}
+      />
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary
- add a reusable full-bleed utility to force media to span the viewport width
- wrap landing page card media in the new container so imagery aligns flush with the screen edges

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d8b30b7b48832da438a782f8a2613c