### PR TITLE
Ensure landing hero image spans the full viewport width

### DIFF
--- a/client/src/pages/landing/HeroSection.tsx
+++ b/client/src/pages/landing/HeroSection.tsx
@@ -74,7 +74,7 @@ export function HeroSection({ onOpenDialog }: HeroSectionProps) {
       <div className="mx-auto grid w-full items-start gap-14 px-6 pb-24 pt-12 md:px-12">
         <div className="space-y-10">
           <div
-            className="relative overflow-hidden bg-cover bg-center px-6 py-14 sm:px-10 sm:py-16"
+            className="relative -mx-6 overflow-hidden bg-cover bg-center px-6 py-14 sm:px-10 sm:py-16 md:-mx-12"
             style={{
               backgroundImage: `linear-gradient(135deg, rgba(15, 23, 42, 0.92), rgba(2, 6, 23, 0.78)), url(${heroCar})`,
             }}


### PR DESCRIPTION
## Summary
- extend the landing hero image container with negative margins so the background reaches the viewport edges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8ba9d415c832db1f6edf6eb46021b