### PR TITLE
Add scroll reveal animations for cards

### DIFF
--- a/client/src/components/admin-dashboard.tsx
+++ b/client/src/components/admin-dashboard.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
+import { useScrollReveal } from "@/hooks/useScrollReveal";
 import { apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
 import { Loader2, MessageSquare, Phone, User, Calendar } from "lucide-react";
@@ -12,6 +13,7 @@ import type { Inquiry } from "@shared/schema";
 export function AdminDashboard() {
   const { toast } = useToast();
   const queryClient = useQueryClient();
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // compact rows expand/collapse state
   const [expandedIds, setExpandedIds] = useState<Record<string, boolean>>({});
@@ -20,6 +22,8 @@ export function AdminDashboard() {
     queryKey: ["/api/inquiries"],
     retry: false,
   });
+
+  useScrollReveal(containerRef, { dependencies: [inquiries] });
 
   const statusMutation = useMutation({
     mutationFn: async ({ id, status }: { id: string; status: string }) => {
@@ -106,7 +110,7 @@ export function AdminDashboard() {
 
   if (error) {
     return (
-      <Card data-testid="error-inquiries">
+      <Card data-testid="error-inquiries" data-animate>
         <CardContent className="py-12 text-center">
           <p className="text-muted-foreground">
             문의 내역을 불러오는 중 오류가 발생했습니다.
@@ -118,7 +122,7 @@ export function AdminDashboard() {
 
   if (!inquiries || (Array.isArray(inquiries) && inquiries.length === 0)) {
     return (
-      <Card data-testid="empty-inquiries">
+      <Card data-testid="empty-inquiries" data-animate>
         <CardContent className="py-12 text-center">
           <MessageSquare className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
           <p className="text-lg font-medium mb-2">접수된 문의가 없습니다</p>
@@ -131,7 +135,7 @@ export function AdminDashboard() {
   }
 
   return (
-    <div className="space-y-6" data-testid="admin-dashboard">
+    <div ref={containerRef} className="space-y-6" data-testid="admin-dashboard">
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold text-primary">문의 내역 관리</h2>
         <Badge variant="secondary" className="text-sm">
@@ -140,104 +144,112 @@ export function AdminDashboard() {
       </div>
 
       <div className="grid gap-6">
-        {
-Array.isArray(inquiries) && inquiries.map((inquiry: Inquiry) => {
-          const isCompact = (inquiry.status === "completed" || inquiry.status === "contacted");
-          const isOpen = expandedIds[inquiry.id] ?? !isCompact;
+        {Array.isArray(inquiries) &&
+          inquiries.map((inquiry: Inquiry, index) => {
+            const isCompact =
+              inquiry.status === "completed" || inquiry.status === "contacted";
+            const isOpen = expandedIds[inquiry.id] ?? !isCompact;
 
-          const toggle = () => {
-            if (isCompact) {
-              setExpandedIds((prev) => ({ ...prev, [inquiry.id]: !isOpen }));
-            }
-          };
+            const toggle = () => {
+              if (isCompact) {
+                setExpandedIds((prev) => ({ ...prev, [inquiry.id]: !isOpen }));
+              }
+            };
 
-          return (
-          <Card key={inquiry.id} className={"shadow-sm " + (isCompact ? "cursor-pointer" : "")} data-testid={`inquiry-${inquiry.id}`}>
-            <CardHeader className="pb-3" onClick={toggle}>
-              {isCompact ? (
-                <div className="flex items-center justify-between">
-                  <div className="text-sm md:text-base font-medium truncate">
-                    {inquiry.name} <span className="text-muted-foreground">{inquiry.phone}</span>
-                    <span className="ml-2 text-xs text-muted-foreground">({getStatusText(inquiry.status || "new")})</span>
-                  </div>
-                  <div className="text-xs text-muted-foreground hidden md:block">
-                    {new Date(inquiry.createdAt!).toLocaleString("ko-KR")}
-                  </div>
-                </div>
-              ) : (
-                <div className="flex items-center justify-between">
-                  <CardTitle className="text-lg flex items-center gap-2">
-                    <User className="w-5 h-5" />
-                    {inquiry.name}
-                  </CardTitle>
-                  <div className="flex items-center gap-2">
-                    <Badge variant={getStatusBadgeVariant(inquiry.status || "new")}>
-                      {getStatusText(inquiry.status || "new")}
-                    </Badge>
-                    <div className="flex items-center text-sm text-muted-foreground">
-                      <Calendar className="w-4 h-4 mr-1" />
-                      {new Date(inquiry.createdAt!).toLocaleString("ko-KR")}
+            return (
+              <Card
+                key={inquiry.id}
+                className={`shadow-sm ${isCompact ? "cursor-pointer" : ""}`}
+                data-testid={`inquiry-${inquiry.id}`}
+                data-animate
+                data-animate-delay={`${index * 0.05}s`}
+              >
+                <CardHeader className="pb-3" onClick={toggle}>
+                  {isCompact ? (
+                    <div className="flex items-center justify-between">
+                      <div className="text-sm md:text-base font-medium truncate">
+                        {inquiry.name} <span className="text-muted-foreground">{inquiry.phone}</span>
+                        <span className="ml-2 text-xs text-muted-foreground">({getStatusText(inquiry.status || "new")})</span>
+                      </div>
+                      <div className="text-xs text-muted-foreground hidden md:block">
+                        {new Date(inquiry.createdAt!).toLocaleString("ko-KR")}
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex items-center justify-between">
+                      <CardTitle className="text-lg flex items-center gap-2">
+                        <User className="w-5 h-5" />
+                        {inquiry.name}
+                      </CardTitle>
+                      <div className="flex items-center gap-2">
+                        <Badge variant={getStatusBadgeVariant(inquiry.status || "new")}>
+                          {getStatusText(inquiry.status || "new")}
+                        </Badge>
+                        <div className="flex items-center text-sm text-muted-foreground">
+                          <Calendar className="w-4 h-4 mr-1" />
+                          {new Date(inquiry.createdAt!).toLocaleString("ko-KR")}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </CardHeader>
+
+                <CardContent className={isOpen ? "space-y-4 pt-0" : "hidden"}>
+                  <div className="grid md:grid-cols-2 gap-4">
+                    <div className="space-y-2">
+                      <div className="flex items-center gap-2 text-sm">
+                        <Phone className="w-4 h-4" />
+                        {inquiry.phone}
+                      </div>
+                      <div className="flex items-start gap-2 text-sm">
+                        <MessageSquare className="w-4 h-4 mt-0.5" />
+                        <span className="whitespace-pre-wrap">{inquiry.inquiry}</span>
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="text-sm">
+                        <span className="text-muted-foreground">등록일:&nbsp;</span>
+                        {new Date(inquiry.createdAt!).toLocaleString("ko-KR")}
+                      </div>
+                      <div className="text-sm">
+                        <span className="text-muted-foreground">상태:&nbsp;</span>
+                        <Badge variant={getStatusBadgeVariant(inquiry.status || "new")}>
+                          {getStatusText(inquiry.status || "new")}
+                        </Badge>
+                      </div>
                     </div>
                   </div>
-                </div>
-              )}
-            </CardHeader>
 
-            <CardContent className={isOpen ? "space-y-4 pt-0" : "hidden"}>
-              <div className="grid md:grid-cols-2 gap-4">
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2 text-sm">
-                    <Phone className="w-4 h-4" />
-                    {inquiry.phone}
+                  {/* 액션 버튼 */}
+                  <div className="flex flex-wrap gap-2 pt-2">
+                    <Button
+                      variant="secondary"
+                      onClick={() => handleStatusChange(inquiry.id, "contacted")}
+                      disabled={statusMutation.isPending}
+                      data-testid={`button-contacted-${inquiry.id}`}
+                    >
+                      연락완료
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => handleStatusChange(inquiry.id, "completed")}
+                      disabled={statusMutation.isPending}
+                      data-testid={`button-completed-${inquiry.id}`}
+                    >
+                      처리완료
+                    </Button>
+                    <Button
+                      onClick={() => handleStatusChange(inquiry.id, "new")}
+                      disabled={statusMutation.isPending}
+                      data-testid={`button-reset-${inquiry.id}`}
+                    >
+                      신규로 변경
+                    </Button>
                   </div>
-                  <div className="flex items-start gap-2 text-sm">
-                    <MessageSquare className="w-4 h-4 mt-0.5" />
-                    <span className="whitespace-pre-wrap">{inquiry.inquiry}</span>
-                  </div>
-                </div>
-                <div className="space-y-2">
-                  <div className="text-sm">
-                    <span className="text-muted-foreground">등록일:&nbsp;</span>
-                    {new Date(inquiry.createdAt!).toLocaleString("ko-KR")}
-                  </div>
-                  <div className="text-sm">
-                    <span className="text-muted-foreground">상태:&nbsp;</span>
-                    <Badge variant={getStatusBadgeVariant(inquiry.status || "new")}>
-                      {getStatusText(inquiry.status || "new")}
-                    </Badge>
-                  </div>
-                </div>
-              </div>
-
-              {/* 액션 버튼 */}
-              <div className="flex flex-wrap gap-2 pt-2">
-                <Button
-                  variant="secondary"
-                  onClick={() => handleStatusChange(inquiry.id, "contacted")}
-                  disabled={statusMutation.isPending}
-                  data-testid={`button-contacted-${inquiry.id}`}
-                >
-                  연락완료
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => handleStatusChange(inquiry.id, "completed")}
-                  disabled={statusMutation.isPending}
-                  data-testid={`button-completed-${inquiry.id}`}
-                >
-                  처리완료
-                </Button>
-                <Button
-                  onClick={() => handleStatusChange(inquiry.id, "new")}
-                  disabled={statusMutation.isPending}
-                  data-testid={`button-reset-${inquiry.id}`}
-                >
-                  신규로 변경
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
-        )})}
+                </CardContent>
+              </Card>
+            );
+          })}
       </div>
     </div>
   );

--- a/client/src/hooks/useScrollReveal.ts
+++ b/client/src/hooks/useScrollReveal.ts
@@ -1,0 +1,76 @@
+import type { DependencyList, RefObject } from "react";
+import { useEffect } from "react";
+
+type UseScrollRevealOptions = {
+  /** 관찰할 요소를 선택하기 위한 셀렉터. 기본값은 `[data-animate]` 입니다. */
+  selector?: string;
+  /** 인터섹션 관찰 임계값. 기본값은 0.2 입니다. */
+  threshold?: number;
+  /** 루트 마진 값. */
+  rootMargin?: string;
+  /** 요소가 보일 때 한 번만 애니메이션을 실행할지 여부. */
+  once?: boolean;
+  /** 의존성 배열. 해당 값이 변경되면 옵저버를 다시 설정합니다. */
+  dependencies?: DependencyList;
+};
+
+/**
+ * 스크롤 시 요소가 부드럽게 나타나는 효과를 적용합니다.
+ * data-animate 속성을 가진 요소를 찾아 `is-visible` 클래스를 추가합니다.
+ */
+export function useScrollReveal(
+  containerRef: RefObject<HTMLElement>,
+  {
+    selector = "[data-animate]",
+    threshold = 0.2,
+    rootMargin = "0px",
+    once = true,
+    dependencies = [],
+  }: UseScrollRevealOptions = {},
+) {
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const elements = Array.from(
+      container.querySelectorAll<HTMLElement>(selector),
+    );
+
+    if (!elements.length) return;
+
+    if (typeof window === "undefined" || !("IntersectionObserver" in window)) {
+      elements.forEach((element) => {
+        element.classList.add("is-visible");
+      });
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const target = entry.target as HTMLElement;
+          if (entry.isIntersecting) {
+            target.classList.add("is-visible");
+            if (once) {
+              observer.unobserve(target);
+            }
+          } else if (!once) {
+            target.classList.remove("is-visible");
+          }
+        });
+      },
+      { threshold, rootMargin },
+    );
+
+    elements.forEach((element) => {
+      if (element.dataset.animateDelay) {
+        element.style.transitionDelay = element.dataset.animateDelay;
+      }
+      observer.observe(element);
+    });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [containerRef, selector, threshold, rootMargin, once, ...dependencies]);
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -1,18 +1,23 @@
+import { useRef } from "react";
 import { AdminDashboard } from "@/components/admin-dashboard";
 import { useAuth } from "@/hooks/useAuth";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { LogOut, User } from "lucide-react";
+import { useScrollReveal } from "@/hooks/useScrollReveal";
 
 export default function Home() {
   const { user } = useAuth();
+  const pageRef = useRef<HTMLDivElement>(null);
+
+  useScrollReveal(pageRef);
 
   const handleLogout = () => {
     window.location.href = "/api/logout";
   };
 
   return (
-    <div className="min-h-screen bg-background">
+    <div ref={pageRef} className="min-h-screen bg-background">
       {/* Header */}
       <header className="border-b border-border">
         <div className="container mx-auto px-4 py-4 flex items-center justify-between">
@@ -43,7 +48,7 @@ export default function Home() {
       {/* Main Content */}
       <main className="container mx-auto px-4 py-8">
         <div className="mb-8">
-          <Card>
+          <Card data-animate>
             <CardHeader>
               <CardTitle className="text-primary">관리자 대시보드</CardTitle>
             </CardHeader>

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { useLocation } from "wouter";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { useToast } from "@/hooks/use-toast";
+import { useScrollReveal } from "@/hooks/useScrollReveal";
 import { apiRequest } from "@/lib/queryClient";
 
 import { LandingHeader } from "./landing/LandingHeader";
@@ -47,33 +48,7 @@ export default function Landing() {
     },
   });
 
-  useEffect(() => {
-    const container = pageRef.current;
-    const elements = container?.querySelectorAll<HTMLElement>("[data-animate]");
-    if (!elements?.length) return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add("is-visible");
-            observer.unobserve(entry.target);
-          }
-        });
-      },
-      { threshold: 0.2 },
-    );
-
-    elements.forEach((el) => {
-      const delay = el.dataset.animateDelay;
-      if (delay) {
-        el.style.transitionDelay = delay;
-      }
-      observer.observe(el);
-    });
-
-    return () => observer.disconnect();
-  }, []);
+  useScrollReveal(pageRef);
 
   const handleFormChange = (field: keyof typeof formData, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));


### PR DESCRIPTION
## Summary
- create a reusable `useScrollReveal` hook to apply intersection observer based animations to elements marked with `data-animate`
- integrate the hook into the landing, admin dashboard, and home pages so cards fade in smoothly when they enter the viewport
- annotate dashboard cards and empty/error states with animation attributes for staggered reveals

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d8c2054380832d869a65b13d373ae5