### PR TITLE
Shorten mobile descriptions on landing page

### DIFF
--- a/client/src/pages/landing/HeroSection.tsx
+++ b/client/src/pages/landing/HeroSection.tsx
@@ -88,8 +88,19 @@ export function HeroSection({ onOpenDialog }: HeroSectionProps) {
                 맞춤 컨설팅으로 완성하는<br />
                 <span className="text-sky-300">프리미엄 차량 렌탈 서비스</span>
               </h2>
-              <p className="text-base leading-relaxed text-slate-100 md:text-lg" data-animate data-animate-delay="0.1s">
+              <p
+                className="hidden text-base leading-relaxed text-slate-100 md:block md:text-lg"
+                data-animate
+                data-animate-delay="0.1s"
+              >
                 일정, 동선, 목적에 따라 가장 완벽한 이동 경험을 설계해 드립니다. 첫 문의부터 차량 반납까지 모든 과정을 전담 매니저가 케어하고, 공항 픽업·호텔 체크인·비즈니스 미팅 등 세부 동선까지 함께 점검하여 고객의 시간을 아껴 드립니다. 서울 곳곳의 파트너 시설과 연계된 특화 혜택으로 이동 이후 일정까지 연속성 있게 이어집니다. 최신형 차량 라인업과 숙련된 기사 네트워크, 목적지와 연계된 맞춤 서비스까지 유기적으로 연결하여 단순한 이동을 넘어서는 고급 모빌리티 경험을 제공합니다.
+              </p>
+              <p
+                className="text-base leading-relaxed text-slate-100 md:hidden"
+                data-animate
+                data-animate-delay="0.1s"
+              >
+                맞춤 컨설팅으로 문의부터 반납까지 전담 매니저가 케어하며, 파트너 혜택과 최신 차량 네트워크로 일정 전체를 자연스럽게 이어 드립니다.
               </p>
               <div className="flex flex-col items-center justify-center gap-3 sm:flex-row" data-animate data-animate-delay="0.15s">
                 <Button
@@ -106,8 +117,19 @@ export function HeroSection({ onOpenDialog }: HeroSectionProps) {
                   <PhoneCall className="h-5 w-5" /> 전화 상담
                 </a>
               </div>
-              <p className="text-sm leading-relaxed text-slate-100/90" data-animate data-animate-delay="0.18s">
+              <p
+                className="hidden text-sm leading-relaxed text-slate-100/90 md:block"
+                data-animate
+                data-animate-delay="0.18s"
+              >
                 고객 전용 앱을 통해 실시간 배차 현황과 기사 정보를 확인하고 필요한 서류를 간편하게 업로드할 수 있습니다. 예약 변경이 발생해도 즉시 알림으로 안내받아 이동 계획을 유연하게 조정할 수 있습니다. 장기 계약 고객에게는 기사 프로필 관리, 자주 방문하는 목적지 자동 등록, 공항 VIP 라운지 동반 등 다양한 부가 혜택이 제공되어 한층 여유로운 여행과 비즈니스 일정이 완성됩니다.
+              </p>
+              <p
+                className="text-sm leading-relaxed text-slate-100/90 md:hidden"
+                data-animate
+                data-animate-delay="0.18s"
+              >
+                전용 앱에서 배차와 기사 정보를 즉시 확인하고 변경 알림을 받을 수 있으며, 장기 고객에게는 기사 관리와 공항 VIP 라운지 등 프리미엄 혜택을 제공합니다.
               </p>
             </div>
           </div>

--- a/client/src/pages/landing/ProcessSection.tsx
+++ b/client/src/pages/landing/ProcessSection.tsx
@@ -11,27 +11,37 @@ const steps = [
     title: "상담 신청",
     description:
       "간단한 문의만 남겨도 담당 매니저가 즉시 연락을 드리고 이동 목적을 세부적으로 확인합니다. 고객의 일정, 동선, 동반 인원, 필요 서비스 등을 체크하여 가장 편안한 이동을 설계할 준비를 마칩니다. 고객이 참고할 수 있도록 예상 견적과 차량 라인업 브로슈어도 함께 전달해 의사 결정 시간을 최소화합니다.",
+    summary: "문의만 남기면 매니저가 즉시 연락해 일정·동선·필요 서비스를 점검하고 견적과 차량 정보를 제공합니다.",
     background: stepBg1,
   },
   {
     title: "맞춤 제안",
     description:
       "필요 일정과 목적에 맞춘 차량·기사·서비스 플랜을 제안하고, 예상 경로에 따른 소요 시간과 비용까지 투명하게 안내합니다. 고객이 원하는 경우 현장 실사를 통해 픽업 동선을 사전에 점검합니다. 국제행사나 대규모 촬영처럼 복합적인 프로젝트에도 일정 관리 전문가가 투입되어 각 파트너사와의 협업을 조율합니다.",
+    summary: "일정과 목적에 맞춘 차량·기사 플랜을 제안하고 경로와 비용을 명확히 안내하며, 필요 시 현장 동선까지 점검합니다.",
     background: stepBg2,
   },
   {
     title: "안전 배차",
     description:
       "완벽한 점검을 마친 차량과 전문 드라이버가 약속된 장소로 배차되며, 실시간 위치 공유를 통해 고객이 대기 시간을 최소화할 수 있습니다. 모든 드라이버는 정기 안전 교육을 이수하고 다국어 의사소통도 지원합니다. 차량 내부에는 공기질 모니터링 시스템과 비상 의료 키트를 비치하여 이동 중 발생할 수 있는 돌발 상황에 즉시 대응합니다.",
+    summary: "점검 완료 차량과 전문 기사가 배차되고 실시간 위치 공유와 다국어·안전 시스템으로 안심 이동을 지원합니다.",
     background: stepBg3,
   },
   {
     title: "사후 케어",
     description:
       "이용 후 추가 일정이나 연장이 필요하면 즉시 이어서 지원하며, 차량 상태 보고와 다음 예약 일정 조율까지 한 번에 진행합니다. 장기 계약 고객에게는 전용 프로모션과 주기적인 서비스 점검을 제공합니다. 만족도 조사를 바탕으로 기사 평가와 서비스 업그레이드 제안서를 전달하여 지속적으로 품질을 개선합니다.",
+    summary: "이용 후에도 연장과 일정 조율을 즉시 돕고, 보고서와 피드백을 반영해 맞춤 혜택과 서비스 개선을 제공합니다.",
     background: stepBg4,
   },
 ];
+
+const processDescriptionDesktop =
+  "모든 상담은 24시간 이내 응답해 드리며, 야간에도 긴급 배차 전담팀이 상시 대기하고 있습니다. 예약 진행 상황은 모바일 알림으로 투명하게 공유되어 고객이 언제든 진행 상황을 확인할 수 있습니다.";
+
+const processDescriptionMobile =
+  "24시간 내 상담 응답과 야간 긴급 배차를 지원하며, 모바일 알림으로 진행 상황을 언제든 확인할 수 있습니다.";
 
 export function ProcessSection() {
   return (
@@ -42,8 +52,21 @@ export function ProcessSection() {
             <p className="text-sm uppercase tracking-[0.35em] text-sky-300">how it works</p>
             <h3 className="mt-4 text-3xl font-semibold text-white md:text-4xl">4단계로 완성되는 프리미엄 예약 프로세스</h3>
           </div>
-          <p className="text-sm leading-relaxed text-slate-200" data-animate data-animate-delay="0.1s">
-            <CalendarRange className="mr-2 inline h-4 w-4 text-sky-300" aria-hidden="true" /> 모든 상담은 24시간 이내 응답해 드리며, 야간에도 긴급 배차 전담팀이 상시 대기하고 있습니다. 예약 진행 상황은 모바일 알림으로 투명하게 공유되어 고객이 언제든 진행 상황을 확인할 수 있습니다.
+          <p
+            className="hidden text-sm leading-relaxed text-slate-200 md:block"
+            data-animate
+            data-animate-delay="0.1s"
+          >
+            <CalendarRange className="mr-2 inline h-4 w-4 text-sky-300" aria-hidden="true" />
+            {processDescriptionDesktop}
+          </p>
+          <p
+            className="text-sm leading-relaxed text-slate-200 md:hidden"
+            data-animate
+            data-animate-delay="0.1s"
+          >
+            <CalendarRange className="mr-2 inline h-4 w-4 text-sky-300" aria-hidden="true" />
+            {processDescriptionMobile}
           </p>
         </div>
         <div className="grid gap-10 -mx-6 md:-mx-12">
@@ -62,7 +85,8 @@ export function ProcessSection() {
                   <CheckCircle2 className="h-5 w-5 text-sky-300" />
                 </div>
                 <h4 className="text-2xl font-semibold text-white">{step.title}</h4>
-                <p className="text-sm leading-relaxed text-slate-100">{step.description}</p>
+                <p className="hidden text-sm leading-relaxed text-slate-100 md:block">{step.description}</p>
+                <p className="text-sm leading-relaxed text-slate-100 md:hidden">{step.summary}</p>
               </div>
             </article>
           ))}

--- a/client/src/pages/landing/SignatureSection.tsx
+++ b/client/src/pages/landing/SignatureSection.tsx
@@ -19,6 +19,7 @@ interface MediaAsset {
 interface HighlightItem {
   title: string;
   description: string;
+  summary: string;
   icon: LucideIcon;
   media: MediaAsset;
 }
@@ -26,6 +27,7 @@ interface HighlightItem {
 interface FleetItem {
   name: string;
   detail: string;
+  summary: string;
   tags: string[];
   media: MediaAsset;
 }
@@ -70,6 +72,7 @@ const highlights: HighlightItem[] = [
     title: "프리미엄 차량 라인업",
     description:
       "벤츠, BMW, 제네시스 등 최신형 수입·국산 차량을 목적과 이동 인원에 맞춰 세심하게 추천합니다. 모든 차량은 주행 전 상태 점검과 실내 살균을 완료하여 언제나 전용차처럼 깨끗한 컨디션을 유지합니다. 고객의 드레스 코드나 브랜드 이미지에 맞춘 컬러 코디네이션, 향기 연출까지 가능해 특별한 순간을 더욱 돋보이게 합니다.",
+    summary: "최신 수입·국산 차량을 목적에 맞춰 추천하고 철저한 관리로 언제나 최상의 컨디션을 제공합니다.",
     icon: Sparkles,
     media: {
       type: "image",
@@ -81,6 +84,7 @@ const highlights: HighlightItem[] = [
     title: "맞춤 컨설팅",
     description:
       "출장, 여행, 비즈니스 등 상황별 이동 목적을 분석해 최적의 차량과 기사, 요금제를 설계합니다. 현장 동선과 예상 이동시간까지 고려한 세부 플랜을 제안해 한 번의 예약으로 모든 일정을 안정적으로 진행할 수 있습니다. 필요 시 숙박 및 레스토랑 예약, 회의 공간 준비 등 연계 서비스도 함께 제공해 이동과 접객이 하나의 흐름으로 이어지도록 돕습니다.",
+    summary: "이동 목적을 분석해 차량·기사·요금제를 설계하고, 현장 동선 점검과 연계 서비스까지 한 번에 지원합니다.",
     icon: Navigation2,
     media: {
       type: "image",
@@ -92,6 +96,7 @@ const highlights: HighlightItem[] = [
     title: "365일 고객 케어",
     description:
       "배차부터 반납까지 전담 매니저가 실시간으로 동행하며 예상치 못한 일정 변경도 즉시 조율합니다. 24시간 케어 센터에서 돌발 상황을 모니터링해 고객이 이동 중에도 안심하고 본연의 일정에 집중할 수 있도록 지원합니다. 이용 후에는 피드백을 바탕으로 맞춤 리포트를 제공하여 다음 예약 시 더 완성도 높은 이동 솔루션을 제안합니다.",
+    summary: "전담 매니저와 24시간 케어 센터가 실시간으로 대응하고, 이용 후 맞춤 리포트까지 제공해 안정적인 이동을 보장합니다.",
     icon: ShieldCheck,
     media: {
       type: "image",
@@ -106,6 +111,7 @@ const fleet: FleetItem[] = [
     name: "Executive Sedan",
     detail:
       "비즈니스 미팅과 장거리 이동을 위한 안락한 세단으로, 에어 서스펜션과 프리미엄 사운드 시스템이 탑재되어 장시간 이동에도 피로감을 줄여 줍니다. 내부 미니바와 충전 설비까지 준비하여 VIP 고객 응대에도 완벽합니다. 방음 처리된 실내 공간과 프라이버시 커튼, 개별 온도 조절 시스템으로 밀도 높은 업무 미팅을 이동 중에도 이어갈 수 있습니다.",
+    summary: "안락한 승차감과 프라이빗 설비를 갖춘 비즈니스 전용 프리미엄 세단입니다.",
     tags: ["E-Class", "G80", "5 Series"],
     media: {
       type: "image",
@@ -117,6 +123,7 @@ const fleet: FleetItem[] = [
     name: "Luxury SUV",
     detail:
       "패밀리 여행과 VIP 픽업에 최적화된 프리미엄 SUV로, 넓은 적재 공간과 독립식 시트 배열을 통해 탑승객 모두가 여유롭게 휴식할 수 있습니다. 파노라마 루프와 엔터테인먼트 시스템이 장착되어 장거리 이동도 즐겁게 만듭니다. 유아 시트와 반려동물 전용 키트도 옵션으로 제공되어 세대와 라이프스타일을 아우르는 이동 환경을 구성합니다.",
+    summary: "넉넉한 공간과 엔터테인먼트 옵션으로 가족과 VIP 모두 편안한 프리미엄 SUV입니다.",
     tags: ["GV80", "XC90", "X5"],
     media: {
       type: "image",
@@ -128,6 +135,7 @@ const fleet: FleetItem[] = [
     name: "Specialty Fleet",
     detail:
       "웨딩카, 프로모션, 행사 전용으로 커스터마이징 가능한 차량으로, 색상 데코와 브랜드 래핑 등 목적에 맞춘 연출이 가능합니다. 전문 코디네이터가 사전 리허설까지 진행해 행사의 분위기를 완벽하게 완성합니다. 퍼레이드 주행, 현장 음향, 포토존 구성까지 한 번에 대응해 브랜드 메시지가 자연스럽게 전달되도록 서포트합니다.",
+    summary: "웨딩·프로모션 등에 맞춰 커스터마이징과 리허설을 지원하는 이벤트 특화 차량입니다.",
     tags: ["AMG", "Convertible", "Sprinter"],
     media: {
       type: "image",
@@ -136,6 +144,12 @@ const fleet: FleetItem[] = [
     },
   },
 ];
+
+const signatureDescriptionDesktop =
+  "수입차 단기 렌트부터 VIP 의전, 웨딩 차량까지 목적별 이동 솔루션을 제공해 드립니다. 전담 매니저가 이동 동선에 맞춰 휴게 지점과 체크인 시간을 조율하고, 필요 시 통역과 보안 인력까지 연계하여 완벽한 토탈 케어를 제공합니다. 고객의 브랜드 캠페인이나 행사 콘셉트에 맞춘 커스터마이징 제안도 함께 드려 서울에서의 모든 순간이 자연스럽게 연결되도록 돕습니다.";
+
+const signatureDescriptionMobile =
+  "수입차 렌트부터 VIP 의전까지 전담 매니저가 동선을 케어하고, 필요 서비스 연계와 맞춤 커스터마이징을 제공합니다.";
 
 export function SignatureSection() {
   return (
@@ -146,8 +160,19 @@ export function SignatureSection() {
           <h3 className="text-3xl font-semibold text-white md:text-4xl" data-animate>
             서울 전 지역 프리미엄 맞춤 렌탈 & 리무진 컨시어지
           </h3>
-          <p className="text-base leading-relaxed text-slate-200" data-animate data-animate-delay="0.05s">
-            수입차 단기 렌트부터 VIP 의전, 웨딩 차량까지 목적별 이동 솔루션을 제공해 드립니다. 전담 매니저가 이동 동선에 맞춰 휴게 지점과 체크인 시간을 조율하고, 필요 시 통역과 보안 인력까지 연계하여 완벽한 토탈 케어를 제공합니다. 고객의 브랜드 캠페인이나 행사 콘셉트에 맞춘 커스터마이징 제안도 함께 드려 서울에서의 모든 순간이 자연스럽게 연결되도록 돕습니다.
+          <p
+            className="hidden text-base leading-relaxed text-slate-200 md:block"
+            data-animate
+            data-animate-delay="0.05s"
+          >
+            {signatureDescriptionDesktop}
+          </p>
+          <p
+            className="text-base leading-relaxed text-slate-200 md:hidden"
+            data-animate
+            data-animate-delay="0.05s"
+          >
+            {signatureDescriptionMobile}
           </p>
           <div className="space-y-12">
             {highlights.map((highlight, index) => (
@@ -164,7 +189,8 @@ export function SignatureSection() {
                   </div>
                   <div className="space-y-3">
                     <h4 className="text-xl font-semibold text-white">{highlight.title}</h4>
-                    <p className="text-sm leading-relaxed text-slate-200">{highlight.description}</p>
+                    <p className="hidden text-sm leading-relaxed text-slate-200 md:block">{highlight.description}</p>
+                    <p className="text-sm leading-relaxed text-slate-200 md:hidden">{highlight.summary}</p>
                   </div>
                 </div>
               </article>
@@ -186,7 +212,8 @@ export function SignatureSection() {
                   <p className="text-xs uppercase tracking-[0.3em] text-slate-300">fleet</p>
                   <h5 className="mt-2 text-2xl font-semibold text-white">{item.name}</h5>
                 </div>
-                <p className="text-sm leading-relaxed text-slate-200">{item.detail}</p>
+                <p className="hidden text-sm leading-relaxed text-slate-200 md:block">{item.detail}</p>
+                <p className="text-sm leading-relaxed text-slate-200 md:hidden">{item.summary}</p>
                 <div className="flex flex-wrap gap-2 text-xs text-slate-200">
                   {item.tags.map((tag) => (
                     <span key={tag} className="rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-slate-100">


### PR DESCRIPTION
## Summary
- add mobile-specific summary variants to the landing hero, process, and signature sections
- show concise copy on small screens while preserving the detailed desktop descriptions
- extend highlight and 차량 데이터 with mobile summaries for consistent messaging

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dd392b74e8832d945a72673a07de83